### PR TITLE
Add FontsWiki to font resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@
 - [Font Joy](https://fontjoy.com/)
 - [Font Squirrel](https://www.fontsquirrel.com/)
 - [Fonts Arena](https://fontsarena.com/)
+- [FontsWiki](https://fontswiki.com/)
 - [Word Mark](https://wordmark.it/)
 - [Type Scale](https://type-scale.com/)
 ------------------------------------------------------------------------------------------------------------------ 


### PR DESCRIPTION
Adds FontsWiki (https://fontswiki.com/) to this repo's relevant font, typography, or design resources section.